### PR TITLE
AMRSW-537 Make visualization_tutorials Noetic compliant by removing tf

### DIFF
--- a/rviz_plugin_tutorials/scripts/send_test_msgs.py
+++ b/rviz_plugin_tutorials/scripts/send_test_msgs.py
@@ -1,17 +1,26 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import roslib; roslib.load_manifest( 'rviz_plugin_tutorials' )
+import roslib
+roslib.load_manifest( 'rviz_plugin_tutorials' )
 from sensor_msgs.msg import Imu
 import rospy
 from math import cos, sin
-import tf
+from transforms3d.euler import euler2quat
+from tf2_ros.transform_broadcaster import TransformBroadcaster
+from geometry_msgs.msg import (
+    Quaternion,
+    Transform,
+    TransformStamped,
+    Vector3
+)
+from std_msgs.msg import Header
 
 topic = 'test_imu'
 publisher = rospy.Publisher( topic, Imu, queue_size=5 )
 
 rospy.init_node( 'test_imu' )
 
-br = tf.TransformBroadcaster()
+br = TransformBroadcaster()
 rate = rospy.Rate(10)
 radius = 5
 angle = 0
@@ -29,11 +38,16 @@ while not rospy.is_shutdown():
 
     publisher.publish( imu )
 
-    br.sendTransform((radius * cos(angle), radius * sin(angle), 0),
-                     tf.transformations.quaternion_from_euler(0, 0, angle),
-                     rospy.Time.now(),
-                     "base_link",
-                     "map")
+    quat = euler2quat(0, 0, angle)
+    t_stamped = TransformStamped(
+        Header(stamp=rospy.Time.now(), frame_id="map"),
+        "base_link",
+        Transform(
+            Vector3(radius * cos(angle), radius * sin(angle), 0),
+            Quaternion(quat[1], quat[2], quat[3], quat[0])
+        )
+    )
+    br.sendTransform(t_stamped)
     angle += .01
     rate.sleep()
 


### PR DESCRIPTION
[AMRSW-537](https://lexxpluss.atlassian.net/browse/AMRSW-537)
Along with LexxAuto, we need to change visualization_tutorials and remove references to tf.

[AMRSW-537]: https://lexxpluss.atlassian.net/browse/AMRSW-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ