### PR TITLE
AMRSW-625 Remove '/' (forward slash) from '/my_frame', which frustratingly makes Rviz unable to show the markers.

### DIFF
--- a/visualization_marker_tutorials/src/basic_shapes.cpp
+++ b/visualization_marker_tutorials/src/basic_shapes.cpp
@@ -52,7 +52,7 @@ int main( int argc, char** argv )
   {
     visualization_msgs::Marker marker;
     // Set the frame ID and timestamp.  See the TF tutorials for information on these.
-    marker.header.frame_id = "/my_frame";
+    marker.header.frame_id = "my_frame";
     marker.header.stamp = ros::Time::now();
 // %EndTag(MARKER_INIT)%
 

--- a/visualization_marker_tutorials/src/points_and_lines.cpp
+++ b/visualization_marker_tutorials/src/points_and_lines.cpp
@@ -46,7 +46,7 @@ int main( int argc, char** argv )
   {
 // %Tag(MARKER_INIT)%
     visualization_msgs::Marker points, line_strip, line_list;
-    points.header.frame_id = line_strip.header.frame_id = line_list.header.frame_id = "/my_frame";
+    points.header.frame_id = line_strip.header.frame_id = line_list.header.frame_id = "my_frame";
     points.header.stamp = line_strip.header.stamp = line_list.header.stamp = ros::Time::now();
     points.ns = line_strip.ns = line_list.ns = "points_and_lines";
     points.action = line_strip.action = line_list.action = visualization_msgs::Marker::ADD;


### PR DESCRIPTION
[AMRSW-625](https://lexxpluss.atlassian.net/browse/AMRSW-625)
Fetch unmerged but important PRs from remote repo into our fork

[AMRSW-625]: https://lexxpluss.atlassian.net/browse/AMRSW-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ